### PR TITLE
Harvesting peer addresses

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,6 +10,9 @@ description: |
 summary: |
   A distributed search and analytics solution.
 series: [kubernetes]
+peers:
+  elasticsearch:
+    interface: elasticsearch
 storage:
   data:
     type: filesystem


### PR DESCRIPTION
This commit implements the harvesting of peer address
when new Elasticsearch units are added to the model.
The list of peer address is required for configuring
the Elasticsearch cluster.

At present the one address that is missing from the
peer list is the bind address of the first unit
(by default the leader unit).