### PR TITLE
Resolve dynamic settings transient error with busy loop, readiness probe, and ES Python module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ops
 pyaml
+elasticsearch>=6.0.0,<7.0.0


### PR DESCRIPTION
There are 3 parts to this commit:
1) change from requesting dynamic settings directly via HTTP to using the official Elasticsearch Python module.
2) add a readiness probe in the pod spec.
3) fix the transient error caused by a discrepancy between the number of ES units seen by Juju and the number of nodes actually registered on the ES cluster. More on point 3 below.

There was an error that usually resolved itself, but sometimes led to an incorrect value for the setting discovery.zen.minimum_master_nodes (https://github.com/canonical/elasticsearch-operator/issues/17).

This commit fixes that problem by waiting until the number of ES units seen by Juju matches the number of nodes seen by ES. The "wait" loop pauses 1 second between requesting the number of nodes on the ES cluster.

There are likely more elegant solutions to this problem, but this fix is at least guaranteed to work and ensures split brain is not possible in the ES cluster. I propose we open this as a new issue.